### PR TITLE
Update Ubuntu base image version to 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get upgrade -y && \
-  apt-get install -y openssh-server gettext-base rsyslog
+  apt-get install -y openssh-server gettext-base
 ADD entrypoint.sh /usr/bin/entrypoint.sh
 ADD sshd_configs_raw /tmp/
 ADD keys /tmp/

--- a/agent-forwarding-disabled/Dockerfile
+++ b/agent-forwarding-disabled/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get upgrade -y && \
-    apt-get install -y openssh-server rsyslog
+    apt-get install -y openssh-server
 ADD agent-forwarding-disabled/entrypoint.sh /usr/bin/entrypoint.sh
 ADD agent-forwarding-disabled/sshd_config /etc/ssh/sshd_config
 ADD keys /tmp/

--- a/agent-forwarding-disabled/entrypoint.sh
+++ b/agent-forwarding-disabled/entrypoint.sh
@@ -31,7 +31,6 @@ add_credential $ADMIN
 
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
-rsyslogd
 
 echo 'Start daemon'
 /usr/sbin/sshd -D

--- a/agent-forwarding-disabled/sshd_config
+++ b/agent-forwarding-disabled/sshd_config
@@ -1,5 +1,4 @@
 PubkeyAuthentication yes
-RSAAuthentication yes
 HostbasedAuthentication no
 PasswordAuthentication no
 AllowGroups remote

--- a/authykey/Dockerfile
+++ b/authykey/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y curl
-RUN apt-get install -y curl openssh-server rsyslog && \
+RUN apt-get install -y curl openssh-server && \
     curl -O 'https://raw.githubusercontent.com/authy/authy-ssh/master/authy-ssh'
 
 ADD entrypoint.sh /usr/bin/entrypoint.sh

--- a/authykey/entrypoint.sh
+++ b/authykey/entrypoint.sh
@@ -30,7 +30,6 @@ add_credential $ADMIN
 
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
-rsyslogd
 
 echo 'Start daemon'
 /usr/sbin/sshd -D

--- a/authykey/sshd_config
+++ b/authykey/sshd_config
@@ -1,5 +1,4 @@
 PubkeyAuthentication yes
-RSAAuthentication yes
 HostbasedAuthentication no
 PasswordAuthentication no
 AllowGroups remote

--- a/authypass/Dockerfile
+++ b/authypass/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y curl
-RUN apt-get install -y curl openssh-server rsyslog && \
+RUN apt-get install -y curl openssh-server && \
     curl -O 'https://raw.githubusercontent.com/authy/authy-ssh/master/authy-ssh'
 
 ADD entrypoint.sh /usr/bin/entrypoint.sh

--- a/authypass/entrypoint.sh
+++ b/authypass/entrypoint.sh
@@ -23,7 +23,6 @@ done
 
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
-rsyslogd
 
 echo 'Start daemon'
 /usr/sbin/sshd -D

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,6 @@ add_credential $ADMIN
 
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
-rsyslogd
 
 echo 'Start daemon'
 /usr/sbin/sshd -D

--- a/gateway-ports/Dockerfile
+++ b/gateway-ports/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get upgrade -y && \
-    apt-get install -y openssh-server python rsyslog
+    apt-get install -y openssh-server python
 ADD gateway-ports/http.py /opt/http/http.py
 ADD gateway-ports/entrypoint.sh /usr/bin/entrypoint.sh
 ADD gateway-ports/sshd_config /etc/ssh/sshd_config

--- a/gateway-ports/entrypoint.sh
+++ b/gateway-ports/entrypoint.sh
@@ -31,7 +31,6 @@ add_credential $ADMIN
 
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
-rsyslogd
 
 echo 'Start dummy HTTP server'
 python /opt/http/http.py &

--- a/gateway-ports/sshd_config
+++ b/gateway-ports/sshd_config
@@ -1,5 +1,4 @@
 PubkeyAuthentication yes
-RSAAuthentication yes
 HostbasedAuthentication no
 PasswordAuthentication no
 AllowGroups remote

--- a/http-proxy/Dockerfile
+++ b/http-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y squid
 COPY squid.conf /etc/squid3/squid.conf

--- a/keyboard-interactive-pass/Dockerfile
+++ b/keyboard-interactive-pass/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get upgrade -y && \
-    apt-get install -y openssh-server rsyslog
+    apt-get install -y openssh-server
 ADD keyboard-interactive-pass/entrypoint.sh /usr/bin/entrypoint.sh
 ADD keyboard-interactive-pass/sshd_config /etc/ssh/sshd_config
 ADD keys /tmp/

--- a/keyboard-interactive-pass/entrypoint.sh
+++ b/keyboard-interactive-pass/entrypoint.sh
@@ -27,7 +27,6 @@ add_credential $ADMIN $ADMIN_PASS
 
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
-rsyslogd
 
 echo 'Start daemon'
 /usr/sbin/sshd -D

--- a/mosh/Dockerfile
+++ b/mosh/Dockerfile
@@ -1,12 +1,12 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get upgrade -y && \
-    apt-get install -y openssh-server rsyslog mosh
+    apt-get install -y openssh-server mosh locales
 
 RUN locale-gen en_US.UTF-8
 
-ADD entrypoint.sh /usr/bin/entrypoint.sh
-ADD sshd_configs_raw/sshd_config /etc/ssh/sshd_config
+ADD mosh/entrypoint.sh /usr/bin/entrypoint.sh
+ADD mosh/sshd_config /etc/ssh/sshd_config
 ADD keys /tmp/
 
 RUN chmod +x /usr/bin/entrypoint.sh

--- a/mosh/entrypoint.sh
+++ b/mosh/entrypoint.sh
@@ -31,7 +31,6 @@ add_credential $ADMIN
 
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
-rsyslogd
 
 echo 'Start sshd'
 /usr/sbin/sshd -D

--- a/mosh/sshd_config
+++ b/mosh/sshd_config
@@ -5,4 +5,3 @@ AllowGroups remote
 AuthorizedKeysFile .ssh/authorized_keys
 LogLevel DEBUG3
 SyslogFacility AUTH
-AuthenticationMethods publickey,password

--- a/multiple-auths/Dockerfile
+++ b/multiple-auths/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get upgrade -y && \
-    apt-get install -y openssh-server rsyslog
+    apt-get install -y openssh-server
 ADD multiple-auths/entrypoint.sh /usr/bin/entrypoint.sh
 ADD multiple-auths/sshd_config /etc/ssh/sshd_config
 ADD keys /tmp/

--- a/multiple-auths/entrypoint.sh
+++ b/multiple-auths/entrypoint.sh
@@ -32,7 +32,6 @@ add_credential $ADMIN $ADMIN_PASS
 
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
-rsyslogd
 
 echo 'Start daemon'
 /usr/sbin/sshd -D

--- a/otp/Dockerfile
+++ b/otp/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y curl
 RUN \
     apt-get update && \
-    apt-get install -y openssh-server rsyslog && \
+    apt-get install -y openssh-server && \
     apt-get install -y otpw-bin libpam-otpw
 ADD entrypoint.sh /usr/bin/entrypoint.sh
 ADD sshd_config /etc/ssh/sshd_config

--- a/otp/entrypoint.sh
+++ b/otp/entrypoint.sh
@@ -18,7 +18,6 @@ add_credential $ADMIN $ADMIN_PASS
 
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
-rsyslogd
 
 echo 'Start daemon'
 /usr/sbin/sshd -D

--- a/pass/Dockerfile
+++ b/pass/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get upgrade -y && \
-    apt-get install -y openssh-server rsyslog
+    apt-get install -y openssh-server
 ADD pass/entrypoint.sh /usr/bin/entrypoint.sh
 ADD pass/sshd_config /etc/ssh/sshd_config
 ADD keys /tmp/

--- a/pass/entrypoint.sh
+++ b/pass/entrypoint.sh
@@ -28,7 +28,6 @@ add_credential $ADMIN $ADMIN_PASS
 
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
-rsyslogd
 
 echo 'Start daemon'
 /usr/sbin/sshd -D

--- a/sftp-disabled/Dockerfile
+++ b/sftp-disabled/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get upgrade -y && \
-    apt-get install -y openssh-server rsyslog
+    apt-get install -y openssh-server
 
 ADD entrypoint.sh /usr/bin/entrypoint.sh
 ADD keys /tmp/

--- a/sshd_configs_raw/sshd_config
+++ b/sshd_configs_raw/sshd_config
@@ -1,5 +1,4 @@
 PubkeyAuthentication yes
-RSAAuthentication yes
 HostbasedAuthentication no
 PasswordAuthentication no
 AllowGroups remote

--- a/sshd_configs_raw/sshd_config_ciphers
+++ b/sshd_configs_raw/sshd_config_ciphers
@@ -1,5 +1,4 @@
 PubkeyAuthentication yes
-RSAAuthentication yes
 HostbasedAuthentication no
 PasswordAuthentication no
 AllowGroups remote

--- a/sshd_configs_raw/sshd_config_kex
+++ b/sshd_configs_raw/sshd_config_kex
@@ -1,5 +1,4 @@
 PubkeyAuthentication yes
-RSAAuthentication yes
 HostbasedAuthentication no
 PasswordAuthentication no
 AllowGroups remote

--- a/sshd_configs_raw/sshd_config_macs
+++ b/sshd_configs_raw/sshd_config_macs
@@ -1,5 +1,4 @@
 PubkeyAuthentication yes
-RSAAuthentication yes
 HostbasedAuthentication no
 PasswordAuthentication no
 AllowGroups remote

--- a/sshd_configs_raw/sshd_config_no_pf
+++ b/sshd_configs_raw/sshd_config_no_pf
@@ -1,5 +1,4 @@
 PubkeyAuthentication yes
-RSAAuthentication yes
 HostbasedAuthentication no
 PasswordAuthentication no
 AllowGroups remote

--- a/sshd_configs_raw/sshd_config_no_sftp
+++ b/sshd_configs_raw/sshd_config_no_sftp
@@ -1,5 +1,4 @@
 PubkeyAuthentication yes
-RSAAuthentication yes
 HostbasedAuthentication no
 PasswordAuthentication no
 AllowGroups remote

--- a/yubikey-pam/Dockerfile
+++ b/yubikey-pam/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y curl rsyslog
 RUN \

--- a/yubikey-pam/entrypoint.sh
+++ b/yubikey-pam/entrypoint.sh
@@ -11,7 +11,6 @@ create_user $ADMIN
 
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
-rsyslogd
 
 echo 'Start daemon'
 /usr/sbin/sshd -D

--- a/yubikey/Dockerfile
+++ b/yubikey/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get upgrade -y && \
-    apt-get install -y openssh-server rsyslog
+    apt-get install -y openssh-server
 
 RUN \
     apt-get install -y gnupg2 pcscd scdaemon curl \

--- a/yubikey/entrypoint.sh
+++ b/yubikey/entrypoint.sh
@@ -21,12 +21,11 @@ create_user "$ADMIN"
 add_credential "$ADMIN"
 
 pkill ssh-agent ; pkill gpg-agent ; \
-  eval "$(gpg-agent --daemon --enable-ssh-support --use-standard-socket \
-  --log-file ~/.gnupg/gpg-agent.log --write-env-file)"
+  eval "$(gpg-agent --daemon --enable-ssh-support \
+  --log-file ~/.gnupg/gpg-agent.log)"
 echo 'Start daemon'
 
 touch /var/log/auth.log
 chmod 666 /var/log/auth.log
-rsyslogd
 
 /usr/sbin/sshd -D

--- a/yubikey/sshd_config
+++ b/yubikey/sshd_config
@@ -1,5 +1,4 @@
 PubkeyAuthentication yes
-RSAAuthentication yes
 HostbasedAuthentication no
 PasswordAuthentication no
 AllowGroups remote


### PR DESCRIPTION
- Removed rsyslog installation in Dockerfiles because 18.04 already has one
- Removed RSAAuthentication option in sshd_config files (deprecated). OpenSSH version: 7.6p1
- Added password authentication to mosh host